### PR TITLE
fix(connectors-it): pre-load CSI sidecar images before rollout wait

### DIFF
--- a/.github/workflows/connectors-integration-test.yaml
+++ b/.github/workflows/connectors-integration-test.yaml
@@ -172,7 +172,73 @@ jobs:
           docker tag nginx:1.23.2 "$NGINX_PATH"
           kind load docker-image "$NGINX_PATH" --name connectors-ci
 
-      - name: Deploy connectors (kind-bootstrap)
+      - name: Build install manifest (make dist)
+        id: build-manifest
+        working-directory: connectors
+        env:
+          KIND_IMAGE: kindest/node:v1.33.1
+          REPLACE_IMG: "n"
+          TAG_OWNER_SOURCE: ci
+          GOMAXPROCS: "4"
+        run: |
+          set -euo pipefail
+          CLUSTER_NAME=connectors-ci
+          KIND_KUBECONFIG="$HOME/.kube/kind-$CLUSTER_NAME"
+          kind get kubeconfig --name "$CLUSTER_NAME" > "$KIND_KUBECONFIG"
+          chmod 600 "$KIND_KUBECONFIG"
+
+          export TAG="$CLUSTER_NAME"
+          export KIND_KUBECONFIG
+          export KUBECONFIG="$KIND_KUBECONFIG"
+          export KO_DOCKER_REPO=kind.local
+          export KIND_CLUSTER_NAME="$CLUSTER_NAME"
+
+          # Install cert-manager with upstream quay.io images (REPLACE_IMG=n).
+          make certmanager
+
+          # Build install.yaml. ko resolves :image refs for cmd/* to
+          # kind.local/... and loads them into the kind cluster automatically.
+          make dist
+
+          echo "--- dist/install.yaml images ---"
+          grep -E '^\s*image:' dist/install.yaml | awk '{print $NF}' | sort -u
+
+      - name: Pre-load 3rd-party sidecar images into Kind
+        working-directory: connectors
+        run: |
+          set -euo pipefail
+          # Any image in the generated install.yaml that points at a private
+          # Alauda registry (not kind.local/ and not ko://) needs a public
+          # stand-in loaded into the kind node, otherwise the rollout wait in
+          # `make deploy` will time out.
+          #
+          # Current mapping (k8s CSI sidecars on Alauda's 3rdparty mirror):
+          #   registry.alauda.cn:60070/3rdparty/k8scsi/<name>:<upstream-tag>-<sha>
+          #     -> registry.k8s.io/sig-storage/<name>:<upstream-tag>
+          PRIVATE=$(grep -E '^\s*image:' dist/install.yaml \
+            | awk '{print $NF}' \
+            | grep -vE '^(kind\.local/|ko://)' \
+            | sort -u)
+          for ref in $PRIVATE; do
+            echo "=== resolving public stand-in for $ref ==="
+            case "$ref" in
+              *registry.alauda.cn*3rdparty/k8scsi/*)
+                name=$(echo "$ref" | sed -E 's|.*/3rdparty/k8scsi/([^:]+):.*|\1|')
+                # Strip Alauda's `-<sha>` rebuild suffix, keep the upstream tag.
+                tag=$(echo "$ref" | sed -E 's|.*:([^:]+)$|\1|' | sed -E 's/-[a-f0-9]+$//')
+                public="registry.k8s.io/sig-storage/${name}:${tag}"
+                echo "pulling $public -> retag as $ref"
+                docker pull "$public"
+                docker tag  "$public" "$ref"
+                kind load docker-image "$ref" --name connectors-ci
+                ;;
+              *)
+                echo "WARNING: no public mapping for $ref — rollout may fail"
+                ;;
+            esac
+          done
+
+      - name: Deploy connectors (kubectl apply + rollout wait)
         id: deploy
         working-directory: connectors
         env:
@@ -182,24 +248,15 @@ jobs:
           GOMAXPROCS: "4"
         run: |
           set -euo pipefail
-          # Reuse the kind cluster created by helm/kind-action by making the
-          # connectors Makefile point at its kubeconfig/name instead of
-          # creating a fresh cluster.
           CLUSTER_NAME=connectors-ci
-          KIND_KUBECONFIG="$HOME/.kube/kind-$CLUSTER_NAME"
-          kind get kubeconfig --name "$CLUSTER_NAME" > "$KIND_KUBECONFIG"
-          chmod 600 "$KIND_KUBECONFIG"
-
-          export TAG="$CLUSTER_NAME"                 # matches kind cluster name
-          export KIND_KUBECONFIG
-          export KUBECONFIG="$KIND_KUBECONFIG"
+          export KUBECONFIG="$HOME/.kube/kind-$CLUSTER_NAME"
+          export TAG="$CLUSTER_NAME"
           export KO_DOCKER_REPO=kind.local
           export KIND_CLUSTER_NAME="$CLUSTER_NAME"
 
-          # cert-manager with upstream quay.io images (REPLACE_IMG=n).
-          make certmanager
-
-          make dist
+          # `make deploy` depends on `dist`. The install.yaml is already on
+          # disk from the previous step, so ko won't rebuild — it'll just
+          # re-emit the same manifest and then `kubectl apply`+ rollout-wait.
           make deploy
 
       - name: Show deployed resources (debug)


### PR DESCRIPTION
CSI DaemonSet pulls two sidecars from `registry.alauda.cn:60070/3rdparty/k8scsi/` which is unreachable from GitHub-hosted runners. Previous run (https://github.com/AlaudaDevops/run-actions/actions/runs/24835079504) got stuck 7+ minutes in deploy — cancelled to save minutes. This PR scans the generated manifest for private registry image refs, pulls the public sig-storage equivalents, retags them to the exact path used in the manifest, and `kind load`s them before the rollout wait.