### PR TITLE
fix(connectors-it): inject token for go-mod git fallback

### DIFF
--- a/.github/workflows/connectors-integration-test.yaml
+++ b/.github/workflows/connectors-integration-test.yaml
@@ -140,6 +140,19 @@ jobs:
             connectors/go.sum
             connectors/testing/go.sum
 
+      - name: Configure git token for go mod git fallback
+        # Some AlaudaDevops/* pseudo-versions pinned in go.mod aren't
+        # cached on proxy.golang.org, so Go falls back to `git ls-remote`
+        # direct. Anonymous git fails on GHA's ubuntu runners ("could not
+        # read Username ... terminal prompts disabled") — so rewrite
+        # https://github.com/ URLs to include the secrets.TOKEN so git
+        # authenticates and the fallback works.
+        env:
+          TOKEN: ${{ secrets.TOKEN }}
+        run: |
+          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
+          echo "git config applied (token redacted)"
+
       - name: Set up ko
         uses: ko-build/setup-ko@v0.8
         with:


### PR DESCRIPTION
persist-credentials: false wasn't enough. Inject the TOKEN into https://github.com/ via url.insteadOf so `git ls-remote` works for pseudo-versions not cached by proxy.golang.org.