### PR TITLE
feat(connectors-it): bump godog concurrency to 2

### DIFF
--- a/.github/workflows/connectors-integration-test.yaml
+++ b/.github/workflows/connectors-integration-test.yaml
@@ -309,7 +309,7 @@ jobs:
         working-directory: connectors/testing
         env:
           REPORT: allure
-          GODOG_ARGS: "--godog.format=allure --godog.concurrency=1"
+          GODOG_ARGS: "--godog.format=allure --godog.concurrency=2"
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
GHA ubuntu-latest has 4 vCPU / 16 GB — running 2 BDD scenarios in parallel should halve wall-time from ~30 min/pass to ~15. Shared-state conflicts, if any, will surface as test failures.