### PR TITLE
fix(devops-demo): expand workflow_call inputs to multi-line form

### DIFF
--- a/.github/workflows/devops-demo-validate-v1.yaml
+++ b/.github/workflows/devops-demo-validate-v1.yaml
@@ -64,12 +64,29 @@ on:
         default: 30
   workflow_call:
     inputs:
-      repository:           { required: true,  type: string }
-      pr_number:            { required: false, type: string, default: "" }
-      branch:               { required: false, type: string, default: "" }
-      head_sha:             { required: false, type: string, default: "" }
-      golangci_lint_version:{ required: false, type: string, default: "v2.11.4" }
-      timeout_minutes:      { required: false, type: number, default: 30 }
+      repository:
+        required: true
+        type: string
+      pr_number:
+        required: false
+        type: string
+        default: ""
+      branch:
+        required: false
+        type: string
+        default: ""
+      head_sha:
+        required: false
+        type: string
+        default: ""
+      golangci_lint_version:
+        required: false
+        type: string
+        default: "v2.11.4"
+      timeout_minutes:
+        required: false
+        type: number
+        default: 30
     secrets:
       TOKEN:
         required: true


### PR DESCRIPTION
## Summary

GitHub Actions rejected dispatches against \`devops-demo-validate-v1\` with \`HTTP 422: Workflow does not have 'workflow_dispatch' trigger\` because the YAML parser failed on the flow-mapping form \`key:{ ... }\` (no space between \`:\` and \`{\`) used in \`workflow_call.inputs\`. Expanding each input to the canonical multi-line form fixes the parse without changing semantics.

Verified clean with \`actionlint v1.7.7\`.

## Test plan

- [x] \`actionlint\` clean
- [ ] After merge: dispatch works from devops-demo's caller without HTTP 422