### PR TITLE
chore(devops-demo): drop smoke-dry-run gate

### DIFF
--- a/.github/workflows/devops-demo-validate-v1.yaml
+++ b/.github/workflows/devops-demo-validate-v1.yaml
@@ -94,7 +94,6 @@ permissions:
 
 env:
   STATUS_CONTEXT: "DevOps Demo CI"
-  KUBECONFORM_VERSION: "v0.7.0"
 
 jobs:
   # --- target resolution + pending status -------------------------------
@@ -304,35 +303,6 @@ jobs:
             -o dist/devops-demo-${GOOS}-${GOARCH} \
             ./cmd/devops-demo
 
-  smoke-dry-run:
-    name: smoke-dry-run
-    needs: resolve
-    runs-on: ubuntu-latest
-    timeout-minutes: ${{ fromJSON(inputs.timeout_minutes) }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          repository: ${{ inputs.repository }}
-          ref: ${{ needs.resolve.outputs.head_sha }}
-          submodules: recursive
-          token: ${{ secrets.TOKEN }}
-          persist-credentials: false
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-          cache: true
-      - name: install kubeconform
-        run: |
-          set -euo pipefail
-          curl -sSL "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" \
-            | tar xz -C /tmp
-          sudo install -m 0755 /tmp/kubeconform /usr/local/bin/kubeconform
-          kubeconform -v
-      - name: make build
-        run: make build
-      - name: make smoke-dry-run
-        run: make smoke-dry-run
-
   schema-golden:
     name: schema-golden
     needs: resolve
@@ -367,7 +337,6 @@ jobs:
       - agent-guide-drift
       - openspec
       - build
-      - smoke-dry-run
       - schema-golden
     runs-on: ubuntu-latest
     steps:
@@ -382,13 +351,12 @@ jobs:
           R_I18N:              ${{ needs.i18n.result }}
           R_AGENT_GUIDE:       ${{ needs['agent-guide-drift'].result }}
           R_BUILD:             ${{ needs.build.result }}
-          R_SMOKE:             ${{ needs['smoke-dry-run'].result }}
           R_SCHEMA:            ${{ needs['schema-golden'].result }}
         run: |
           set -euo pipefail
           STATE=success
           DESC="DevOps Demo gates passed"
-          for r in "$R_RESOLVE" "$R_TEST" "$R_LINT" "$R_I18N" "$R_AGENT_GUIDE" "$R_BUILD" "$R_SMOKE" "$R_SCHEMA"; do
+          for r in "$R_RESOLVE" "$R_TEST" "$R_LINT" "$R_I18N" "$R_AGENT_GUIDE" "$R_BUILD" "$R_SCHEMA"; do
             case "$r" in
               success) ;;
               cancelled)


### PR DESCRIPTION
## Summary
- Drops the `smoke-dry-run` job from `devops-demo-validate-v1.yaml`
- Drops the now-unused `KUBECONFORM_VERSION` env
- Drops `smoke-dry-run` from the finalize aggregate

## Context
The devops-demo repo deletes its `configs/` example folder in [AlaudaDevops/devops-demo#117](https://github.com/AlaudaDevops/devops-demo/pull/117). Each example was an environment snapshot with hardcoded host IPs that did not match any operator's cluster — sending users down dead ends. `internal/config/defaults.yaml` is now the canonical config template (still emitted by `devops-demo init`), and the smoke-dry-run Makefile target has been removed since it had nothing to iterate over.

## Merge order
Land **after** AlaudaDevops/devops-demo#117 merges. Merging earlier removes a still-passing gate; merging later leaves the workflow failing on a deleted Makefile target.

## Test plan
- [ ] After merge, observe the next devops-demo PR's `DevOps Demo CI` status — should be `success` from the remaining gates (test, lint, i18n, agent-guide-drift, build matrix, schema-golden) without the smoke-dry-run job in the runs list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)