### PR TITLE
fix(sync-docs): pass commit message via env to avoid shell injection

### DIFF
--- a/.github/workflows/sync-docs-advanced.yml
+++ b/.github/workflows/sync-docs-advanced.yml
@@ -56,9 +56,10 @@ jobs:
     steps:
     - name: Check if this is a reverse sync commit
       id: check_reverse_sync
+      env:
+        COMMIT_MSG: ${{ github.event.head_commit.message }}
       run: |
-        commit_msg="${{ github.event.head_commit.message }}"
-        if echo "$commit_msg" | grep -q "\[reverse-sync\]"; then
+        if echo "$COMMIT_MSG" | grep -qF "[reverse-sync]"; then
           echo "reverse_sync=true" >> $GITHUB_OUTPUT
           echo "🔄 This commit is from reverse sync - skipping forward sync to prevent loop"
         else


### PR DESCRIPTION
## Summary

The first step of `.github/workflows/sync-docs-advanced.yml` (`Check if this is a reverse sync commit`) interpolated `github.event.head_commit.message` directly into the run script body via `${{ ... }}`. GitHub Actions performs that substitution at script-generation time, so any shell metacharacters in the commit message (backticks, `$(...)`, unmatched parens) are evaluated by bash before the script runs.

This is a long-standing GitHub Actions footgun — [security hardening guidance](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable) explicitly calls it out.

## Why this surfaced now (the bug has always been there)

This vulnerability has been latent in the workflow since it was written. It only manifests when a commit message **happens to contain shell metacharacters**. Most commit messages on `AlaudaDevops/connectors-operator` are plain `feat: …` / `fix: …` / `chore(deps): …` — they sail through unscathed, so the workflow *looks* like it has always worked.

The triggering commit ([b0ffcb5](https://github.com/AlaudaDevops/connectors-operator/commit/b0ffcb5e409c42cde3f3d897c7ab74b6d30be61b) on `connectors-operator` main) was a **squash merge of PR #1274** with a richly-formatted body. Squash merges concatenate every sub-commit's message into one big `head_commit.message`, so backtick-quoted code references get concentrated:

> Fix the param names ... \`ERROR: nexusServerURL is required\` from the Task.
> ... closing \`)\` got removed alongside the GitHub URL ...

After GitHub Actions templated that into the shell script, bash parsed the backticks as command substitution and tried to run `ERROR: nexusServerURL is required` as a command. The stray ``` ` ` ` ``` around an unmatched `)` produced an additional syntax error:

```
.sh: line 73: ERROR:: command not found
.sh: line 73: nexusServerURL: command not found
.sh: line 73: source-files: command not found
.sh: command substitution: line 73: syntax error near unexpected token `)'
Process completed with exit code 127.
```

[Failed run on connectors-operator](https://github.com/AlaudaDevops/connectors-operator/actions/runs/27669993421). Looking at the recent `Sync Documentation` run history confirms the pattern — failures and successes are interleaved, correlated 1:1 with whether that push's `head_commit.message` happened to contain shell metacharacters:

```
[FAIL] 27669993421   ← b0ffcb5 (this one)
[ok]   27652652330
[FAIL] 27652631071
[FAIL] 27651473322
[ok]   27588813705
[FAIL] 27537265826
...
```

The irony: developers writing **good** commit messages — quoting code identifiers, param names, and error strings with backticks for readability — are exactly the ones who trip this. Commit messages must be treated as untrusted input to the shell even when they come from your own team.

Every subsequent docs push from `connectors-operator` is now blocked at this same step until either b0ffcb5 is rewritten (not viable — already on main) or this workflow is fixed.

## Fix

Pass the message through the `env:` block (`COMMIT_MSG`) instead of inline template expansion. Env values are injected by the runner **at execution time** as plain process-environment strings; bash sees a normal variable and never re-parses its content. Backticks, `$(...)`, quotes, parens — all become literal characters.

Also switch `grep -q "\[reverse-sync\]"` to `grep -qF "[reverse-sync]"` so the marker is matched as a fixed string — no regex escape needed, and slightly more robust if the marker syntax ever changes.

```diff
     - name: Check if this is a reverse sync commit
       id: check_reverse_sync
+      env:
+        COMMIT_MSG: ${{ github.event.head_commit.message }}
       run: |
-        commit_msg="${{ github.event.head_commit.message }}"
-        if echo "$commit_msg" | grep -q "\[reverse-sync\]"; then
+        if echo "$COMMIT_MSG" | grep -qF "[reverse-sync]"; then
```

## Verification

A side-by-side test workflow on [kycheng/run-actions @ test/verify-shell-injection-fix](https://github.com/kycheng/run-actions/blob/test/verify-shell-injection-fix/.github/workflows/test-shell-injection-fix.yml) runs both the OLD inline-expansion pattern and the NEW env-injection pattern against the same synthetic input mimicking b0ffcb5's commit message:

```
docs: fix `ERROR: nexusServerURL is required` (closing `)` got dropped
```

**Run: https://github.com/kycheng/run-actions/actions/runs/27734838849**

| Job | Outcome | Observed in logs |
|---|---|---|
| OLD pattern (`commit_msg="${{ inputs.message }}"`) | ❌ failure | `line 1: ERROR:: command not found` + `syntax error near unexpected token \`)'` → exit 2, exact same failure mode as the original incident |
| NEW pattern (`env: COMMIT_MSG: ${{ inputs.message }}`) | ✅ success | `reverse_sync=false` printed cleanly; backticks treated as literal characters |

This proves the fix end-to-end on real GitHub-hosted runners, not just in theory. The test workflow and branch are one-offs and will be deleted after merge.

## Test plan

- [x] Reviewed remaining workflow steps — `github.event.head_commit.message` is not interpolated anywhere else in this file (or anywhere else under `.github/`); `pusher.name` / `pusher.email` / `github.ref` only contain values constrained by git/GitHub and are safe.
- [x] YAML still parses (validated locally).
- [x] End-to-end side-by-side reproduction on GitHub Actions confirms OLD pattern fails, NEW pattern passes, on b0ffcb5-shaped input — see Verification section.
- [ ] After merge, retrigger the `Sync Documentation` workflow on `connectors-operator` main against b0ffcb5 to confirm the sync runs through (or wait for the next `docs/**` push).